### PR TITLE
Property type coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.5.0 (2016-10-18)
+- Added gem Virtus for static type coercion
+
 ## 0.4.2 (2016-10-18)
 - Added 'require time' to Timestamps module
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 0.5.0 (2016-10-18)
-- Added gem Virtus for static type coercion
+- Added gem Coercible for static type coercion
 
 ## 0.4.2 (2016-10-18)
 - Added 'require time' to Timestamps module

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DataSteroid is an ODM (Object-Document-Mapper) framework for Google Datastore in
 Install
 -------
 ```ruby
-gem 'data_steroid', '~> 0.4.2'
+gem 'data_steroid'
 ```
 
 Configure
@@ -28,8 +28,8 @@ class Product
   kind 'Product' # Datastore Kind
 
   property :barcode
-  property :name
-  property :price
+  property :name, String # optional type
+  property :price, Float # optional type
 
   validates :barcode, :name, :price, presence: true
 end

--- a/data_steroid.gemspec
+++ b/data_steroid.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activemodel', '~> 4.2'
   gem.add_dependency 'activesupport', '~> 4.2'
+  gem.add_dependency 'coercible', '~> 1.0'
   gem.add_dependency 'google-cloud-datastore', '~> 0.20'
-  gem.add_dependency 'virtus', '~> 1.0.5'
 end

--- a/data_steroid.gemspec
+++ b/data_steroid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'data_steroid'
-  gem.version     = '0.4.3'
+  gem.version     = '0.5.0'
   gem.date        = '2016-09-12'
   gem.summary     = "Google Datastore ODM"
   gem.description = "Simple ODM to Google Datastore based on Mongoid"

--- a/data_steroid.gemspec
+++ b/data_steroid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'data_steroid'
-  gem.version     = '0.4.2'
+  gem.version     = '0.4.3'
   gem.date        = '2016-09-12'
   gem.summary     = "Google Datastore ODM"
   gem.description = "Simple ODM to Google Datastore based on Mongoid"
@@ -14,7 +14,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3.0"
 
-  gem.add_dependency 'google-cloud-datastore', '~> 0.20'
-  gem.add_dependency 'activesupport', '~> 4.2'
   gem.add_dependency 'activemodel', '~> 4.2'
+  gem.add_dependency 'activesupport', '~> 4.2'
+  gem.add_dependency 'google-cloud-datastore', '~> 0.20'
+  gem.add_dependency 'virtus', '~> 1.0.5'
 end

--- a/lib/data_steroid/entity/initializable.rb
+++ b/lib/data_steroid/entity/initializable.rb
@@ -5,13 +5,18 @@ module DataSteroid
       extend ActiveSupport::Concern
 
       included do
-        def initialize(options = nil)
+        def initialize(params = nil)
           set_default_values
-          if options.is_a? Google::Cloud::Datastore::Entity
-            properties_names.each { |a| send("#{a}=", options[a.to_s]) }
-            send('id=', options.key.id)
-          elsif options.is_a? ::Hash
-            options.each_pair { |key, value| send("#{key}=", value) }
+          case params
+          when Google::Cloud::Datastore::Entity
+            properties_names.each do |property_name|
+              send("#{property_name}=", params[property_name.to_s])
+            end
+            send('id=', params.key.id)
+          when ::Hash
+            params.each_pair do |key, value|
+              send("#{key}=", value)
+            end
           end
         end
       end

--- a/lib/data_steroid/entity/initializable.rb
+++ b/lib/data_steroid/entity/initializable.rb
@@ -6,12 +6,9 @@ module DataSteroid
 
       included do
         def initialize(options = nil)
-          set_default_values
+          super(options)
           if options.is_a? Google::Cloud::Datastore::Entity
-            properties_names.each { |a| send("#{a}=", options[a.to_s]) }
             send('id=', options.key.id)
-          elsif options.is_a? ::Hash
-            options.each_pair { |key, value| send("#{key}=", value) }
           end
         end
       end

--- a/lib/data_steroid/entity/initializable.rb
+++ b/lib/data_steroid/entity/initializable.rb
@@ -6,9 +6,12 @@ module DataSteroid
 
       included do
         def initialize(options = nil)
-          super(options)
+          set_default_values
           if options.is_a? Google::Cloud::Datastore::Entity
+            properties_names.each { |a| send("#{a}=", options[a.to_s]) }
             send('id=', options.key.id)
+          elsif options.is_a? ::Hash
+            options.each_pair { |key, value| send("#{key}=", value) }
           end
         end
       end

--- a/lib/data_steroid/properties.rb
+++ b/lib/data_steroid/properties.rb
@@ -1,4 +1,4 @@
-require 'virtus'
+require 'coercible'
 
 module DataSteroid
   # Define behaviour to properties of entity.
@@ -6,20 +6,73 @@ module DataSteroid
     extend ActiveSupport::Concern
 
     included do
-      include Virtus.model
+      class_attribute :properties
 
       class << self
-        alias_method :property, :attribute
+        alias_method :property, :add_property
       end
 
-      alias_method :properties, :attributes
+      self.properties = {}
 
-      attribute :id # Default attribute
+      property :id # Default property
+
+      def properties=(properties)
+        if properties.is_a? ::Hash
+          properties.each_pair { |key, value| send("#{key}=", value) }
+        else
+          raise Datastore::Errors::DatastoreError.new 'Properties params must be a Hash'
+        end
+      rescue
+        raise Datastore::Errors::DatastoreError.new 'Property invalid'
+      end
+
+      def properties_names
+        properties.keys
+      end
+
+      protected
+
+      def set_default_values
+        properties.each_pair do |name, options|
+          next unless options.key? :default
+          default = options[:default]
+          # Default might be a lambda
+          value = default.respond_to?(:call) ? default.call : default
+          send("#{name}=", value)
+        end
+      end
+
+      def coercer
+        @coercer ||= Coercible::Coercer.new
+      end
     end
 
     class_methods do
-      def properties_names
-        attribute_set.map{ |s| s.instance_variable_name.split('@')[1].to_sym }
+      protected
+
+      def add_property(name, *args)
+        options = args[-1].is_a?(Hash) ? args.pop : {}
+        options[:type] = args[0] if args[0].is_a?(Class)
+        properties[name.to_s] = options
+        create_accessors(name, options)
+        self
+      end
+
+      # https://www.leighhalliday.com/ruby-metaprogramming-creating-methods
+      def create_accessors(name, options)
+        define_method(name) do # Define get method
+          instance_variable_get("@#{name}")
+        end
+
+        define_method("#{name}=") do |value| # Define set method
+          coerced_value =
+            if options[:type]
+              coercer[value.class].send("to_#{options[:type].to_s.downcase}", value)
+            else
+              value
+            end
+          instance_variable_set("@#{name}", coerced_value)
+        end
       end
     end
   end

--- a/lib/data_steroid/timestamps.rb
+++ b/lib/data_steroid/timestamps.rb
@@ -6,8 +6,8 @@ module DataSteroid
     extend ActiveSupport::Concern
 
     included do
-      property :created_at, Time, default: DateTime.now
-      property :updated_at, time
+      property :created_at, default: ->{ DateTime.now }
+      property :updated_at
 
       before_save :set_updated_at
 

--- a/lib/data_steroid/timestamps.rb
+++ b/lib/data_steroid/timestamps.rb
@@ -6,8 +6,8 @@ module DataSteroid
     extend ActiveSupport::Concern
 
     included do
-      property :created_at, default: DateTime.now
-      property :updated_at
+      property :created_at, Time, default: DateTime.now
+      property :updated_at, time
 
       before_save :set_updated_at
 

--- a/lib/data_steroid/version.rb
+++ b/lib/data_steroid/version.rb
@@ -1,5 +1,5 @@
 module DataSteroid
   # version string
   # @api public
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/lib/data_steroid/version.rb
+++ b/lib/data_steroid/version.rb
@@ -1,5 +1,5 @@
 module DataSteroid
   # version string
   # @api public
-  VERSION = '0.4.3'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
Este patch tem como objetivo facilitar a inter-operação entre o gRPC e o Data Store.
## Problema

Caso em questão: pra um servidor do gRPC que recebe uma série de parâmetros definidos no proto, sendo alguns ENUM e outros string:

``` ruby
# do lado do servidor
require 'grpc'
require 'data_steroid'

class GeofencingService < Geofencing::Service
  def create_event(request, _unused_call)
    puts "create_event: #{request.to_h}"
    event = Event.new(request.to_h)
    event.save
  end
```

Resultado:

``` ruby
create_event: {:platform=>:ANDROID, :location=>nil, :transition=>:ENTER, :name=>"fio-fio-beauty-club", :user=>"giovanni-bonetti", :business=>"fio-fio-beauty-club"}
exception: {"exception"=>"Google::Cloud::Datastore::PropertyError", "message"=>"A property of type Symbol is not supported.", "backtrace"=>"./server.rb:23:in `create_event'"}
```

O problema é o seguinte: se é enviada um _enum_, ele é transformado em _symbol_. Contudo o Datastore precisa que isso seja transformado em _string_ no momento de salvar. E depois, na hora de ler de volta o registro do Datastore, é necessário transformá-lo em _symbol_ de volta.
## Solução

Pra resolver isso, acho que uma boa solução é utilizar a gem Virtus pra cuidar dessa parte dos atributos. Ela tem um suporte legal a essa parte de coerção:

``` ruby
class Event
  include DataSteroid::Entity

  kind 'Event'

  property :platform, String
  property :transition, String
  property :name, String
  property :user, String
  property :business, String

  ...
end

e = Event.new(platform: :ANDROID, transition: :ENTER, user: 1, business: 1)
e.platform # 'ANDROID'
e.transition # 'ENTER'
e.user # '1' (repare que eh uma string no lugar de INT)
e.business # '1' (idem) 
```

Isso é útil até pra coerções mais complexas, como `Array[Integer]` e `Hash[String => String]`. Isso pode ser útil na hora de serializar um hash, já que normalmente no Ruby os hashes são construídos com assinatura `Hash[Symbol => String]`.
