### PR TITLE
Storage coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.5.1 (2016-10-19)
+- Added coercion to Datastore types (on save)
+
 ## 0.5.0.1 (2016-10-19)
 - Fixed rubygems date
 

--- a/data_steroid.gemspec
+++ b/data_steroid.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |gem|
   gem.name        = 'data_steroid'
-  gem.version     = '0.5.0.1'
-  gem.date        = '2016-10-19'
+  gem.version     = '0.5.1'
+  gem.date        = '2016-10-20'
   gem.summary     = "Google Datastore ODM"
   gem.description = "Simple ODM to Google Datastore based on Mongoid"
   gem.authors     = ["Fabio Tomio"]

--- a/lib/data_steroid/entity.rb
+++ b/lib/data_steroid/entity.rb
@@ -29,17 +29,18 @@ module DataSteroid
       def to_gcloud
         hash = {}
         properties_names.each do |property|
-          hash[property] = send(property)
+          hash[property] = type_cast_for_storage send(property)
         end
         hash.sort.to_h
       end
 
       def to_csv
-        values = to_gcloud.sort.to_h.values.map! do |v| 
-          if v.class == Time
-            v.to_formatted_s(:db)
+        values = to_gcloud.sort.to_h.values.map! do |value|
+          case value
+          when Time
+            value.to_formatted_s(:db)
           else
-            v.to_s.gsub(',', '')
+            value.to_s.gsub(',', '')
           end
         end
         values.join(',')
@@ -47,6 +48,17 @@ module DataSteroid
 
       def self.kind(kind_name)
         self.kind = kind_name
+      end
+
+      protected
+
+      def type_cast_for_storage(value)
+        case value
+        when Symbol
+          value.to_s
+        else
+          value
+        end
       end
     end
 

--- a/lib/data_steroid/entity.rb
+++ b/lib/data_steroid/entity.rb
@@ -27,11 +27,9 @@ module DataSteroid
       end
 
       def to_gcloud
-        hash = {}
-        properties_names.each do |property|
+        properties_names.each_with_object({}) do |property, hash|
           hash[property] = type_cast_for_storage send(property)
         end
-        hash.sort.to_h
       end
 
       def to_csv
@@ -52,6 +50,7 @@ module DataSteroid
 
       protected
 
+      # Based on https://github.com/rails/rails/blob/v5.0.0.1/activerecord/lib/active_record/type_caster/map.rb
       def type_cast_for_storage(value)
         case value
         when Symbol

--- a/lib/data_steroid/persistable/savable.rb
+++ b/lib/data_steroid/persistable/savable.rb
@@ -16,29 +16,31 @@ module DataSteroid
             send(name)
           end
 
-          @gcloud_entity ||= self.class.datastore_entity
-
           to_gcloud.each_pair do |key, value|
             if key == 'id' && value.present?
-              @gcloud_entity.key = gcloud_key unless @gcloud_entity.persisted?
-              next
-            end
-            if value.present?
-              @gcloud_entity[key] = value
-            elsif @gcloud_entity.properties.exist? key
-              @gcloud_entity.properties.delete key
+              gcloud_entity.key = gcloud_key unless gcloud_entity.persisted?
+            elsif value.present?
+              gcloud_entity[key] = value
+            elsif gcloud_entity.properties.exist? key
+              gcloud_entity.properties.delete key
             end
           end
 
-          if (result = self.class.datastore.save(@gcloud_entity).first)
+          if (result = self.class.datastore.save(gcloud_entity).first)
             send('id=', result.key.id) if id.nil?
             true
           else
             false
           end
         end
+
+        protected
+
+        def gcloud_entity
+          @gcloud_entity ||= self.class.datastore_entity
+        end
       end
-      
+
       class_methods do
         def before_save(method)
           before_save_methods << method

--- a/lib/data_steroid/properties.rb
+++ b/lib/data_steroid/properties.rb
@@ -66,7 +66,7 @@ module DataSteroid
 
         define_method("#{name}=") do |value| # Define set method
           coerced_value =
-            if options[:type]
+            if options[:type] && !value.nil?
               coercer[value.class].send("to_#{options[:type].to_s.downcase}", value)
             else
               value

--- a/lib/data_steroid/version.rb
+++ b/lib/data_steroid/version.rb
@@ -1,5 +1,5 @@
 module DataSteroid
   # version string
   # @api public
-  VERSION = '0.5.0.1'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
No PR anterior, foi adicionada a possibilidade de fazer a coerção dos tipos no momento de inicialização do _model_:

``` ruby
class Event
  include DataSteroid::Entity

  kind 'Event'

  property :platform,   String
  property :transition, String
  property :name,       String
end
```

Contudo, pra poder fazer a comunicação **de volta para o gRPC** ao carregar o dado do _storage_, é necessário separar o tipo do _model_ e o do _storage_. Assim, este patch permite fazer o seguinte:

``` ruby
class Event
  include DataSteroid::Entity
  include DataSteroid::Timestamps

  kind 'Event'

  property :platform,   Symbol # <===== mudou
  property :transition, Symbol # <===== mudou
  property :name,       String
end
```

Assim, nesse caso, o modelo trabalha com o tipo `Symbol`, que é mais próximo do gRPC, e o _storage_ tem uma tabela de conversão - conforme proposto pelo @fabiotomio , que mapeia esse atributo pra um dos tipos básicos que ele tem (no caso String):

``` ruby
module DataSteroid
  # Inject behaviour for Datastore Entity.
  module Entity
    ...

    def to_gcloud
      ...
        hash[property] = type_cast_for_storage send(property)
      ...
    end

    ...
    protected

    def type_cast_for_storage(value)
      case value
      when Symbol
        value.to_s
      else
        value
      end
    end

  end

end
```
## Observações

Por hora eu só tratei esse conversão de Symbol -> String, mas poderia adicionar também o caso que o @tiagopog mencionou ontem do Hash. No modelo o atributo é manipulado como Hash, mas na hora de salvar pode ser salvo como:
- String JSON
  - Exemplo:
  
  ``` ruby
  # no modelo
  x.name = {a: 1, b: {c: 2, d: [3,4]}}
  
  # no storage
  {
  "name" => '{"a": 1, "b": {"c": 2, "d": [3,4] }}'
  }
  ```
  - vantagens:
    - fácil de implementar a serialização e deserialização
  - desvantagens:
    - ruim pra indexar;
    - adiciona dependências da biblioteca JSON;
    - há várias bibliotecas JSON em Ruby, cada uma com seus prós e contras

---
- Utilizando a estratégia do ElasticSearch:
  - Exemplo:
  
  ``` ruby
  # no modelo
  x.name = {a: 1, b: {c: 2, d: [3,4]}}
  
  # no storage
  {
  "name.a" => 1,
  "name.b.c" => 2,
  "name.b.d[0]" => 3,  
  "name.b.d[1]" => 4
  }
  ```
  - vantagens:
    - possibilidade de indexação (os arrays devem dar mais dor de cabeça);
    - não gera novas dependências;
  - desvantagens:
    - complexidade de implementação (por exemplo, campos com '.' precisam ser escapados).
