### PR TITLE
Suportar o uso de chave não geradas automaticamente

### DIFF
--- a/lib/data_steroid/entity/initializable.rb
+++ b/lib/data_steroid/entity/initializable.rb
@@ -12,7 +12,7 @@ module DataSteroid
             properties_names.each do |property_name|
               send("#{property_name}=", params[property_name.to_s])
             end
-            send('id=', params.key.id)
+            send('id=', params.key.id || params.key.name)
           when ::Hash
             params.each_pair do |key, value|
               send("#{key}=", value)

--- a/lib/data_steroid/persistable/savable.rb
+++ b/lib/data_steroid/persistable/savable.rb
@@ -27,7 +27,7 @@ module DataSteroid
           end
 
           if (result = self.class.datastore.save(gcloud_entity).first)
-            send('id=', result.key.id) if id.nil?
+            send('id=', result.key.id || result.key.name) if id.nil?
             true
           else
             false

--- a/lib/data_steroid/version.rb
+++ b/lib/data_steroid/version.rb
@@ -1,5 +1,5 @@
 module DataSteroid
   # version string
   # @api public
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
Quando deixamos de usar o id "auto gerado" pelo Datastore, não usamos `key.id`, devemos usar `key.name`.

# Exemplos da interface

## Na escolha da chave
![screen shot 2017-01-11 at 16 38 05](https://cloud.githubusercontent.com/assets/22549/21861524/5d776390-d81c-11e6-8e80-57feaa161044.png)

## Diferentes chaves na listagem
![screen shot 2017-01-11 at 16 39 38](https://cloud.githubusercontent.com/assets/22549/21861590/a3b16306-d81c-11e6-8ea8-25f79e6a8303.png)

